### PR TITLE
Make installation python 2.7 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 language: python
 
 python:
+  - "2.7"
   - "3.5"
   - "3.6"
 

--- a/django_admin_json_editor/admin.py
+++ b/django_admin_json_editor/admin.py
@@ -10,7 +10,7 @@ class JSONEditorWidget(forms.Widget):
     template_name = 'django_admin_json_editor/editor.html'
 
     def __init__(self, schema, collapsed=True, sceditor=False):
-        super(JSONEditorWidget).__init__()
+        super(JSONEditorWidget, self).__init__()
         self._schema = schema
         self._collapsed = collapsed
         self._sceditor = sceditor

--- a/django_admin_json_editor/admin.py
+++ b/django_admin_json_editor/admin.py
@@ -10,12 +10,12 @@ class JSONEditorWidget(forms.Widget):
     template_name = 'django_admin_json_editor/editor.html'
 
     def __init__(self, schema, collapsed=True, sceditor=False):
-        super().__init__()
+        super(JSONEditorWidget).__init__()
         self._schema = schema
         self._collapsed = collapsed
         self._sceditor = sceditor
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if callable(self._schema):
             schema = self._schema(self)
         else:

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 import os
 import re
-from pathlib import Path
 from setuptools import setup
 
 
-project_path = Path(__file__).parent
+project_path = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(project_path, 'README.md'), 'r') as fout:
+    README = fout.read()
+with open(os.path.join(project_path, 'django_admin_json_editor', '__init__.py'), 'r') as fout:
+    version_text = fout.read()
 
-README = (project_path / 'README.md').read_text()
-
-version_text = (project_path / 'django_admin_json_editor' / '__init__.py').read_text()
 VERSION = re.compile(r'.*__version__ = \'(.*?)\'', re.S).match(version_text).group(1)
 
 # allow setup.py to be run from any path

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = true
-envlist = py35, py36
+envlist = py27, py35, py36
 
 [testenv]
 passenv = LC_ALL, LANG, HOME


### PR DESCRIPTION
I tried to install it under Python 2.7 where `pathlib` is not available by default.