### PR TITLE
editor value updated after manually (via json) deleting entries or editing select fields 

### DIFF
--- a/django_admin_json_editor/static/django_admin_json_editor/jsoneditor/jsoneditor.min.js
+++ b/django_admin_json_editor/static/django_admin_json_editor/jsoneditor/jsoneditor.min.js
@@ -426,7 +426,7 @@ e?this.canHaveAdditionalProperties()?b?this.addproperty_add.disabled=!1:this.add
 // First, set the values for all of the defined properties
 d(this.cached_editors,function(d,e){
 // Value explicitly set
-"undefined"!=typeof a[d]?(c.addObjectProperty(d),e.setValue(a[d],b)):b||c.isRequired(e)?e.setValue(e.getDefault(),b):c.removeObjectProperty(d)}),d(a,function(a,d){c.cached_editors[a]||(c.addObjectProperty(a),c.editors[a]&&c.editors[a].setValue(d,b))}),this.refreshValue(),this.layoutEditors(),this.onChange()},showValidationErrors:function(a){var b=this,c=[],e=[];
+"undefined"!=typeof a[d]?(c.addObjectProperty(d),e.setValue(a[d],b)):b||c.isRequired(e)?e.setValue(e.getDefault(),b):c.removeObjectProperty(d)}),d(a,function(a,d){c.cached_editors[a]||(c.addObjectProperty(a),c.editors[a]&&c.editors[a].setValue(d,b))}),this.refreshValue(),this.layoutEditors(),this.onChange(),this.change()},showValidationErrors:function(a){var b=this,c=[],e=[];
 // Show errors for this editor
 if(d(a,function(a,d){d.path===b.path?c.push(d):e.push(d)}),this.error_holder)if(c.length){this.error_holder.innerHTML="",this.error_holder.style.display="",d(c,function(a,c){b.error_holder.appendChild(b.theme.getErrorMessage(c.message))})}else this.error_holder.style.display="none";
 // Show error for the table row if this is inside a table


### PR DESCRIPTION
After manually deleting entries or editing values for select fields the editor value was not updated. Consequently editor.getValue() returned the old value. 

This commit should fix both issues by calling `this.change()`. A similar fix was successfully applied for the json-editor library, see more details here: https://github.com/jdorn/json-editor/pull/752. But it addressed only the issue with editing select field values.