### PR TITLE
Problem with widget rendering passed schema

### DIFF
--- a/django_admin_json_editor/admin.py
+++ b/django_admin_json_editor/admin.py
@@ -4,6 +4,7 @@ import collections
 from django import forms
 from django.utils.safestring import mark_safe
 from django.template.loader import render_to_string
+import json
 
 
 class JSONEditorWidget(forms.Widget):
@@ -28,7 +29,7 @@ class JSONEditorWidget(forms.Widget):
 
         context = {
             'name': name,
-            'schema': schema,
+            'schema': json.dumps(schema),
             'data': value,
             'sceditor': int(self._sceditor),
         }


### PR DESCRIPTION
Hi,
I had a problem with rendering the widget with any dict schema passed.
My project uses py2.7 and django 1.11.10

It seems that when pure dict is passed to the context it doesn't turn into a json string that schema attribute for the JS part likes to render.
it turns into a string that contains {u'title': 'sometitle'}

I've added json.dumps to assure json string is sent to the context and now widget renders the schema properly.
