### PR TITLE
Fixes property selector popup widget

### DIFF
--- a/django_admin_json_editor/static/django_admin_json_editor/style.css
+++ b/django_admin_json_editor/static/django_admin_json_editor/style.css
@@ -9,3 +9,11 @@ div.sceditor-container {
     width: 100% !important;
     margin-bottom: 10px;
 }
+
+/*Fixes for property selector*/
+.property-selector label {
+    float: none;
+}
+.property-selector .form-check-label:after {
+    display: none  !important;
+}


### PR DESCRIPTION
This is a CSS fix for the property popover widget, which seems to be conflicting with some styles of Django.

Before:
![Screenshot from 2021-07-05 13-27-30](https://user-images.githubusercontent.com/4420927/124465013-2ecd3c80-dd95-11eb-9cf8-b04c585c95c7.png)
![Screenshot from 2021-07-05 13-27-12](https://user-images.githubusercontent.com/4420927/124465017-2f65d300-dd95-11eb-9a0a-b8bfdba86d1e.png)


After:
![Screenshot from 2021-07-05 13-01-52](https://user-images.githubusercontent.com/4420927/124465038-368ce100-dd95-11eb-9f84-c39d902dd511.png)
![Screenshot from 2021-07-05 13-02-14](https://user-images.githubusercontent.com/4420927/124465031-355bb400-dd95-11eb-8c48-802a7fba9d8a.png)


